### PR TITLE
Refactor: remove en-IE from Intl.NumberFormat and create a `formatNumber` function

### DIFF
--- a/src/components/molecules/stats-card.tsx
+++ b/src/components/molecules/stats-card.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 
 import {shadows, text, colors} from 'theme';
+import {formatNumber} from 'services/i18n';
 
 interface StatsCardProps {
   style?: ViewStyle;
@@ -37,9 +38,7 @@ export const StatsCard: FC<StatsCardProps> = ({
         />
       </View>
       <View style={styles.stats}>
-        <Text style={text.xxlargeBlack}>
-          {new Intl.NumberFormat('en-IE').format(figure)}
-        </Text>
+        <Text style={text.xxlargeBlack}>{formatNumber(figure)}</Text>
         <Text style={text.defaultBoldOpacity70}>{description}</Text>
       </View>
     </View>

--- a/src/components/organisms/app-stats.tsx
+++ b/src/components/organisms/app-stats.tsx
@@ -8,6 +8,7 @@ import {Card} from 'components/atoms/card';
 import {Progress} from 'components/atoms/progress';
 import {colors, text} from 'theme';
 import {BubbleIcons} from 'assets/icons';
+import {formatNumber} from 'services/i18n';
 
 export interface AppStats {
   totalCheckins: number;
@@ -32,7 +33,7 @@ export const AppStats: FC<AppStatsProps> = ({data}) => {
           </View>
           <View style={styles.col}>
             <Text style={text.xxlargeBlack}>
-              {new Intl.NumberFormat('en-IE').format(data.totalCheckins)}
+              {formatNumber(data.totalCheckins)}
             </Text>
             <Text style={styles.text}>{t('appStats:totalCheckins')}</Text>
           </View>
@@ -48,7 +49,7 @@ export const AppStats: FC<AppStatsProps> = ({data}) => {
           </View>
           <View style={styles.rowPercentage}>
             <Text style={text.xxlargeBlack}>
-              {new Intl.NumberFormat('en-IE').format(data.noSymptoms)}
+              {formatNumber(data.noSymptoms)}
             </Text>
             <Text style={text.xlargeBlack}>%</Text>
             <Text>&nbsp;</Text>
@@ -62,7 +63,7 @@ export const AppStats: FC<AppStatsProps> = ({data}) => {
           </View>
           <View style={styles.rowPercentage}>
             <Text style={text.xxlargeBlack}>
-              {new Intl.NumberFormat('en-IE').format(data.someSymptoms)}
+              {formatNumber(data.someSymptoms)}
             </Text>
             <Text style={text.xlargeBlack}>%</Text>
             <Text>&nbsp;</Text>

--- a/src/components/organisms/covid-stats.tsx
+++ b/src/components/organisms/covid-stats.tsx
@@ -9,6 +9,7 @@ import {Card} from 'components/atoms/card';
 import {CountyBreakdownCard} from 'components/molecules/county-breakdown-card';
 import {text} from 'theme';
 import {BubbleIcons} from 'assets/icons';
+import {formatNumber} from 'services/i18n';
 
 interface CovidStatsProps {
   style?: ViewStyle;
@@ -35,7 +36,7 @@ export const CovidStats: FC<CovidStatsProps> = ({
           </View>
           <View style={styles.column} accessible accessibilityRole="text">
             <Text style={[text.xxlargeBlack, styles.columnText]}>
-              {new Intl.NumberFormat('en-IE').format(data.confirmed)}
+              {formatNumber(data.confirmed)}
             </Text>
             <Text style={[text.defaultBoldOpacity70, styles.columnText]}>
               {t('stats:totalConfirmed')}
@@ -48,9 +49,7 @@ export const CovidStats: FC<CovidStatsProps> = ({
             <BubbleIcons.Deaths width={56} height={56} />
           </View>
           <View style={styles.column} accessible accessibilityRole="text">
-            <Text style={text.xxlargeBlack}>
-              {new Intl.NumberFormat('en-IE').format(data.deaths)}
-            </Text>
+            <Text style={text.xxlargeBlack}>{formatNumber(data.deaths)}</Text>
             <Text style={text.defaultBoldOpacity70}>
               {t('stats:totalDeaths')}
             </Text>
@@ -63,7 +62,7 @@ export const CovidStats: FC<CovidStatsProps> = ({
           </View>
           <View style={styles.column} accessible accessibilityRole="text">
             <Text style={text.xxlargeBlack}>
-              {new Intl.NumberFormat('en-IE').format(data.hospitalised)}
+              {formatNumber(data.hospitalised)}
             </Text>
             <Text style={text.defaultBoldOpacity70}>
               {t('stats:totalHospitalised')}
@@ -77,7 +76,7 @@ export const CovidStats: FC<CovidStatsProps> = ({
           </View>
           <View style={styles.column} accessible accessibilityRole="text">
             <Text style={text.xxlargeBlack}>
-              {new Intl.NumberFormat('en-IE').format(data.requiredICU)}
+              {formatNumber(data.requiredICU)}
             </Text>
             <Text style={text.defaultBoldOpacity70}>
               {t('stats:requiredICU')}

--- a/src/components/views/county-breakdown.tsx
+++ b/src/components/views/county-breakdown.tsx
@@ -8,6 +8,7 @@ import {colors, text} from 'theme';
 import {Heading} from 'components/atoms/heading';
 import {useApplication} from 'providers/context';
 import {Scrollable} from 'components/templates/scrollable';
+import {formatNumber} from 'services/i18n';
 
 export const CountyBreakdown = () => {
   const {t} = useTranslation();
@@ -62,7 +63,7 @@ export const CountyBreakdown = () => {
                   {cases <= 5 && <Text style={text.largeBold}>&le;5</Text>}
                   {cases > 5 && (
                     <Text maxFontSizeMultiplier={1.5} style={text.largeBold}>
-                      {new Intl.NumberFormat('en-IE').format(cases)}
+                      {formatNumber(cases)}
                     </Text>
                   )}
                 </View>

--- a/src/services/i18n/index.ts
+++ b/src/services/i18n/index.ts
@@ -41,4 +41,9 @@ i18n
     }
   });
 
+export const formatNumber = (value: number): string => {
+  const currentLanguage = i18n.language;
+  return new Intl.NumberFormat(currentLanguage).format(value);
+};
+
 export default i18n;


### PR DESCRIPTION
This PR closes #50 

Add a `formatNumber` function that reads the current locale from `i18n`.