### PR TITLE
Clickable link for Apache 2.0 license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Copyright (c) The COVID Green Contributors
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
The current page link isn't clickable but is shown to the users as follows:

    [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)

The blockquote means that Markdown syntax for a url isn't applied. This makes the link clickable which appears to be what was intended:

[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)